### PR TITLE
Fixed viewport options and path to logo

### DIFF
--- a/AccDC.htm
+++ b/AccDC.htm
@@ -3,6 +3,7 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<title>AccDC - Accelerated Dynamic Content</title>
+	<meta content="width=device-width, initial-scale=1.0" name="viewport" />
 	<meta name="description" content="The AccDC API is a JavaScript based Dynamic Content Management System that automates the rendering of dynamic content to ensure accessibility for screen reader and keyboard only users." />
 	<meta name="keywords" content="interface designs, user interface automation, internet application design, user interface components, application user interface design, dynamic content management, interface designers, rich interface application, dynamic content management system, interface designing, rich internet app, rich internet apps, user interface design web, application ui, ria development, rich internet application design, ui web design, web design user interface, ui interface design, ui designing, automation ui, accessible rich internet application, rich user interface design" />
 	<meta name="Author" content="Bryan Garaventa" />
@@ -22,7 +23,7 @@
 	<header>
 		<h1><strong>AccDC</strong> Accelerated Dynamic Content</h1>
 		<p class="baseline version">AccDC <abbr title="Application Programming Interface">API</abbr> for standalone, version: <span id="AccDCCurrentVerS1"></span></p>
-		<p class="logo"><img alt="WhatSock : Changing the world one step at a time" src="img/whatsock.SVG" /></p>
+		<p class="logo"><img alt="WhatSock : Changing the world one step at a time" src="img/whatsock.svg" /></p>
 	
 		<nav>
 			<h2>Main navigation <a id="skipLink" href="#wrapper">(Jump to main content)</a></h2>


### PR DESCRIPTION
I had to add the meta viewport to "accDC.htm" so the page can be zoomed and behave correctly on smartphones. I've corrected the name of the logo also, that was not loading.
